### PR TITLE
Improve configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ docker run -d -p 3000:3000 \
 -e PORT=3000 \
 -e browserLimit=20 \
 -e timeOut=60000 \
+-e HEADLESS=true \
 zfcsoftware/cf-clearance-scraper:latest
 ```
 
@@ -177,6 +178,12 @@ You can add authorisation by changing the process.env.authToken variable. If thi
 
 ### How Do I Set The Timeout Time?
 You can give the variable process.env.timeOut a value in milliseconds. The default is 60000.
+
+### How Do I Run The Browser Headlessly?
+Set the environment variable `HEADLESS` to `true` to run without opening a visible browser window.
+
+### Can I Specify A Custom User Agent?
+Yes. Pass the `userAgent` field in the JSON body of your request and the browser will use it when visiting the page.
 
 ## Disclaimer of Liability
 This repository was created purely for testing and training purposes. The user is responsible for any prohibited liability that may arise from its use.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-clearance-scraper",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/src/endpoints/getSource.js
+++ b/src/endpoints/getSource.js
@@ -1,4 +1,4 @@
-function getSource({ url, proxy }) {
+function getSource({ url, proxy, userAgent }) {
     return new Promise(async (resolve, reject) => {
 
         if (!url) return reject('Missing url parameter')
@@ -18,6 +18,7 @@ function getSource({ url, proxy }) {
 
         try {
             const page = await context.newPage();
+            if (userAgent) await page.setUserAgent(userAgent);
             await page.setRequestInterception(true);
             page.on('request', async (request) => {
                 try {

--- a/src/endpoints/solveTurnstile.max.js
+++ b/src/endpoints/solveTurnstile.max.js
@@ -1,4 +1,8 @@
-function solveTurnstileMin({ url, proxy }) {
+const fs = require('fs')
+const path = require('path')
+const callbackTemplate = fs.readFileSync(path.join(__dirname, '../data/callback.html'), 'utf8')
+
+function solveTurnstileMin({ url, proxy, userAgent }) {
     return new Promise(async (resolve, reject) => {
 
         if (!url) return reject('Missing url parameter')
@@ -20,6 +24,7 @@ function solveTurnstileMin({ url, proxy }) {
 
         try {
             const page = await context.newPage();
+            if (userAgent) await page.setUserAgent(userAgent);
 
             const client = await page.target().createCDPSession()
             const interceptManager = new RequestInterceptionManager(client)
@@ -45,7 +50,7 @@ function solveTurnstileMin({ url, proxy }) {
                     resourceType: 'Document',
                     modifyResponse({ body }) {
                         return {
-                            body: String(body).replace('</body>', String(require('fs').readFileSync('./src/data/callback.html')) + '</body>')
+                            body: String(body).replace('</body>', callbackTemplate + '</body>')
                         }
                     },
                 }

--- a/src/endpoints/solveTurnstile.min.js
+++ b/src/endpoints/solveTurnstile.min.js
@@ -1,4 +1,8 @@
-function solveTurnstileMin({ url, proxy, siteKey }) {
+const fs = require('fs')
+const path = require('path')
+const fakePageTemplate = fs.readFileSync(path.join(__dirname, '../data/fakePage.html'), 'utf8')
+
+function solveTurnstileMin({ url, proxy, siteKey, userAgent }) {
     return new Promise(async (resolve, reject) => {
 
         if (!url) return reject('Missing url parameter')
@@ -22,6 +26,7 @@ function solveTurnstileMin({ url, proxy, siteKey }) {
 
         try {
             const page = await context.newPage();
+            if (userAgent) await page.setUserAgent(userAgent);
             const client = await page.target().createCDPSession()
             const interceptManager = new RequestInterceptionManager(client)
 
@@ -48,7 +53,7 @@ function solveTurnstileMin({ url, proxy, siteKey }) {
                     resourceType: 'Document',
                     modifyResponse({ body }) {
                         return {
-                            body: String(require('fs').readFileSync('./src/data/fakePage.html')).replace(/<site-key>/g, siteKey),
+                            body: fakePageTemplate.replace(/<site-key>/g, siteKey),
                             status: 200
                         }
                     },

--- a/src/endpoints/wafSession.js
+++ b/src/endpoints/wafSession.js
@@ -9,7 +9,7 @@ async function findAcceptLanguage(page) {
     })
 }
 
-function getSource({ url, proxy }) {
+function getSource({ url, proxy, userAgent }) {
     return new Promise(async (resolve, reject) => {
 
         if (!url) return reject('Missing url parameter')
@@ -29,6 +29,7 @@ function getSource({ url, proxy }) {
 
         try {
             const page = await context.newPage();
+            if (userAgent) await page.setUserAgent(userAgent);
             await page.setRequestInterception(true);
             page.on('request', async (request) => {
                 try {

--- a/src/module/createBrowser.js
+++ b/src/module/createBrowser.js
@@ -8,7 +8,8 @@ async function createBrowser() {
         // console.log('Launching the browser...');
 
         const { browser } = await connect({
-            headless: false,
+            // run in headless mode when HEADLESS environment variable is "true"
+            headless: process.env.HEADLESS === 'true',
             turnstile: true,
             connectOption: { defaultViewport: null },
             disableXvfb: false,

--- a/src/module/reqValidate.js
+++ b/src/module/reqValidate.js
@@ -30,6 +30,9 @@ const schema = {
         },
         "siteKey": {
             "type": "string"
+        },
+        "userAgent": {
+            "type": "string"
         }
     },
     "required": ["mode", "url"],


### PR DESCRIPTION
## Summary
- allow running puppeteer in headless mode with the `HEADLESS` env variable
- support specifying a custom `userAgent` in requests
- reuse HTML templates instead of reading them for every request
- document new options in README
- bump package version to 2.1.0

## Testing
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687472d677b88327aa3cf4e91b33014a